### PR TITLE
Stop calling `rb_obj_id` on T_IMEMO

### DIFF
--- a/ext/allocation_sampler/allocation_sampler.c
+++ b/ext/allocation_sampler/allocation_sampler.c
@@ -105,7 +105,7 @@ make_frame_info(VALUE *frames, int *lines)
 
     for(i = 0; i < count; i++, frames++, lines++) {
 	VALUE line = INT2NUM(*lines);
-	rb_ary_push(rb_frames, rb_ary_new3(2, rb_obj_id(*frames), line));
+	rb_ary_push(rb_frames, rb_ary_new3(2, ULL2NUM(*frames), line));
     }
 
     return rb_frames;
@@ -370,13 +370,13 @@ frames(VALUE self)
 
 	VALUE args[3];
 
-	args[0] = rb_obj_id(*head);
+	args[0] = ULL2NUM(*head);
 	args[1] = rb_profile_frame_full_label(*head);
 	args[2] = file;
 
 	frame = rb_class_new_instance(3, args, rb_cFrame);
 
-	rb_hash_aset(frames, rb_obj_id(*head), frame);
+	rb_hash_aset(frames, ULL2NUM(*head), frame);
 
 	/* Skip duplicates */
 	VALUE *cmp;


### PR DESCRIPTION
In Ruby 3.5 object_id is now an inline property of objects and T_IMEMO can't have fields.

But this code was written in a time when `rb_obj_id` wasn't much more than boxing the object address in a Fixnum, hence we can just explictly do that with `ULL2NUM`.