### PR TITLE
Fix duplicate version constant

### DIFF
--- a/lib/allocation_sampler.rb
+++ b/lib/allocation_sampler.rb
@@ -6,7 +6,6 @@ require 'cgi/escape'
 
 module ObjectSpace
   class AllocationSampler
-    VERSION = '1.0.0'
 
     class Frame
       attr_reader :id, :name, :path, :children


### PR DESCRIPTION
Removes this in favour of [lib/allocation_sampler/version.rb](https://github.com/tenderlove/allocation_sampler/blob/master/lib/allocation_sampler/version.rb)

Causes `warning: already initialized constant ObjectSpace::AllocationSampler::VERSION`
